### PR TITLE
Update references to discordapp.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MobileDiscord
 
-MobileDiscord is a custom third-party mod for Discord (https://discordapp.com/).
+MobileDiscord is a custom third-party mod for Discord (https://discord.com/).
 
 Neither the code nor its author are affiliated with Discord.
 

--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ func getOrigin(req *http.Request) string {
 	} else if strings.HasPrefix(req.Host, "ptb") {
 		return "ptb.discord.com"
 	} else {
-		return "discordapp.com"
+		return "discord.com"
 	}
 }
 
@@ -174,7 +174,7 @@ func modifyResponse(res *http.Response) error {
 				csp = strings.Replace(csp, "'self'", "'self' "+origin, -1)
 				// icons use wrong protocol
 				if res.Request.Header.Get("X-Forwarded-Proto") != "https" {
-					csp = strings.Replace(csp, "https://*.discordapp.com", "*.discordapp.com", -1)
+					csp = strings.Replace(csp, "https://*.discord.com", "*.discord.com", -1)
 					csp = strings.Replace(csp, "wss://*.discord.media", "ws://*.discord.media", -1)
 				}
 				v[i] = csp

--- a/static/mobilediscord.js
+++ b/static/mobilediscord.js
@@ -275,7 +275,7 @@
             window.dispatchEvent(online);
         });
 
-        // HACK: login page must be loaded on discordapp.com for reCAPTCHA
+        // HACK: login page must be loaded on discord.com for reCAPTCHA
         const INIT_SCRIPT = `if (!("mdLocalStorage" in window)) {
     // HACK: Edge 14 is unsupported
     const compatibleUserAgent = navigator.userAgent.replace(" Edge/14.", " Edge/15.");
@@ -345,7 +345,7 @@ mdLocalStorage.token;
                         this.close();
                     }
                 });
-                webview.src = (origin || "https://discordapp.com") + "/login";
+                webview.src = (origin || "https://discord.com") + "/login";
                 document.body.appendChild(webview);
                 webview.focus();
                 appMount.hidden = true;


### PR DESCRIPTION
Discord has changed their primary domain to `discord.com` and any attempt to access `discordapp.com` will redirect.
Changing the URLs appears to resolve this just fine.